### PR TITLE
Fix backspace bug in input.c

### DIFF
--- a/include/input.h
+++ b/include/input.h
@@ -6,6 +6,7 @@
 
 typedef struct {
     char *data;
+    size_t start;
     size_t len;
 } InputBuffer;
 

--- a/src/input.c
+++ b/src/input.c
@@ -30,6 +30,7 @@ void disable_raw_mode(void) {
 
 InputBuffer input_buffer_new(void) {
     InputBuffer buf;
+    buf.start = 0;
     buf.len = 0;
     buf.data = malloc(INPUT_BUFFER_SIZE);
     return buf;
@@ -73,7 +74,7 @@ int update_input_buffer(InputBuffer *buf) {
         return 0; // Unrecognized escape sequence
     } else if (c == 127 || c == '\b') {
         // Backspace
-        if (buf->len > 0) {
+        if (buf->len > buf->start) {
             buf->len--;
             write(STDOUT_FILENO, "\b \b", 3);
         }
@@ -88,6 +89,7 @@ int update_input_buffer(InputBuffer *buf) {
             write(STDOUT_FILENO, "• ", strlen("• "));
             fflush(stdout);
             buf->len -= 1;
+            buf->start = buf->len;
             return 0;
         } else {
             buf->data[buf->len] = '\0';

--- a/src/parse.c
+++ b/src/parse.c
@@ -40,7 +40,6 @@ char *clear_whitespace(const char *input) {
 }
 
 char *parse_double_quotes(char **input) {
-    printf("Input: %s\n", *input);
     *input += 1;
 
     char *token = malloc(strlen(*input) + 1);
@@ -64,7 +63,6 @@ char *parse_double_quotes(char **input) {
 
     token[index] = '\0';
     token = realloc(token, index + 1);
-    printf("Token: %s\n", token);
     return token;
 }
 


### PR DESCRIPTION
Issue: Closes #5

Review: Fix backspace bug where it would allow backspacing after an escaped newline which caused visual artifacts

